### PR TITLE
reverse the order of parameters in the $watch's callback function

### DIFF
--- a/jsTree.directive.js
+++ b/jsTree.directive.js
@@ -108,7 +108,7 @@ ngJSTree.directive('jsTree', ['$http', function($http) {
             treeDir.init(s, e, a, config);
           });
         } else if (a.treeData == 'scope') {
-          s.$watch(a.treeModel, function(o, n) {
+          s.$watch(a.treeModel, function(n, o) {
             if (n) {
               config = {
                 'core': {


### PR DESCRIPTION
The callback function parameters should be "newVal", oldVal".
https://docs.angularjs.org/api/ng/type/$rootScope.Scope#$watch