### PR TITLE
Fixing the attribute for contextmenu plugin.

### DIFF
--- a/jsTree.directive.js
+++ b/jsTree.directive.js
@@ -51,17 +51,7 @@ ngJSTree.directive('jsTree', ['$http', function($http) {
 
         if (config.plugins.indexOf('contextmenu') >= 0) {
           if (a.treeContextmenu) {
-            config.contextmenu = config.contextmenu || {};
-
-            if (a.treeContextmenuaction != undefined) {
-              config.contextmenu.items = function(e) {
-                return s.$eval(a.treeContextmenuaction)(e);
-              }
-            } else {
-              config.contextmenu.items = function() {
-                return s[a.treeContextmenu];
-              }
-            }
+            config.contextmenu = s[a.treeContextmenu];
           }
         }
 


### PR DESCRIPTION
This allows the use of all settings (ie : select_node and show_at_node)
The attribute tree-contextmenuaction becomes obsolete BUT users can use a Ojbect of Function on items (like in jsTree)

example :

``` html
<js-tree tree-plugins="contextmenu" tree-contextmenu="contextMenu" />
```

``` javascript
$scope.contextMenu = {
    items: {
      "Node": {
        "label" : "Node",
         "action" : function(obj) { 
          alert('node')
        }
      }
    }
  };
```

Here is a plunker (I reuse the same idea of  #10 )
http://plnkr.co/edit/qr8vittbOwvRkNrtQyjz?p=preview

PS : I make this PullRequest to use select_node option. I would understand if it's not merged.
